### PR TITLE
feat: add PDF upload endpoint with pdfplumber text extraction

### DIFF
--- a/backend/agents/serializers.py
+++ b/backend/agents/serializers.py
@@ -5,3 +5,24 @@ class LinkedInRequestSerializer(serializers.Serializer):
     description = serializers.CharField(min_length=10, max_length=2000)
     tone = serializers.ChoiceField(choices=["professionnel", "storytelling", "technique"])
     session_id = serializers.UUIDField()
+
+
+class CvRequestSerializer(serializers.Serializer):
+    job_offer = serializers.CharField(min_length=20, max_length=5000)
+    session_id = serializers.UUIDField()
+    cv = serializers.FileField()
+    cover_letter = serializers.FileField(required=False)
+
+    def validate_cv(self, value):
+        if not value.name.endswith('.pdf'):
+            raise serializers.ValidationError("Le CV doit être un fichier PDF.")
+        if value.size > 5 * 1024 * 1024:
+            raise serializers.ValidationError("Le CV ne doit pas dépasser 5 Mo.")
+        return value
+
+    def validate_cover_letter(self, value):
+        if value and not value.name.endswith('.pdf'):
+            raise serializers.ValidationError("La lettre de motivation doit être un fichier PDF.")
+        if value and value.size > 5 * 1024 * 1024:
+            raise serializers.ValidationError("La lettre de motivation ne doit pas dépasser 5 Mo.")
+        return value

--- a/backend/agents/services/cv_agent.py
+++ b/backend/agents/services/cv_agent.py
@@ -1,1 +1,38 @@
-# Implemented in feat/cv-agent-api
+import pdfplumber
+from io import BytesIO
+
+from .claude_client import stream, ClaudeError
+
+SYSTEM_PROMPT = """Tu es un expert en recrutement et en rédaction de CV et lettres de motivation.
+Tu adaptes le CV et la lettre de motivation d'un candidat à une offre d'emploi spécifique.
+Tu mets en avant les compétences et expériences les plus pertinentes pour le poste.
+Tu écris uniquement en français.
+Tu retournes uniquement le contenu adapté, sans commentaire ni explication."""
+
+
+def extract_text_from_pdf(file_bytes: bytes) -> str:
+    with pdfplumber.open(BytesIO(file_bytes)) as pdf:
+        pages = [page.extract_text() or "" for page in pdf.pages]
+    text = "\n\n".join(pages).strip()
+    if not text:
+        raise ClaudeError("Le PDF ne contient pas de texte extractible.")
+    return text
+
+
+def generate(job_offer: str, cv_text: str, cover_letter_text: str):
+    """
+    Yields adapted CV + cover letter token by token.
+    cache_system=True because the system prompt is reused across requests.
+    """
+    user_message = f"""Offre d'emploi :
+{job_offer}
+
+CV actuel :
+{cv_text}
+
+Lettre de motivation actuelle :
+{cover_letter_text}
+
+Adapte le CV et la lettre de motivation à cette offre d'emploi."""
+
+    yield from stream(SYSTEM_PROMPT, user_message, cache_system=True)

--- a/backend/agents/tests/test_cv_agent.py
+++ b/backend/agents/tests/test_cv_agent.py
@@ -1,0 +1,155 @@
+import io
+import json
+import uuid
+from unittest.mock import patch, MagicMock
+from django.test import TestCase, Client
+from agents.models import Session, GenerationHistory
+from agents.services.cv_agent import extract_text_from_pdf
+from agents.services.claude_client import ClaudeError
+
+
+def _make_pdf(text="Mon CV en Python"):
+    """Creates a minimal in-memory PDF with pdfplumber-readable text."""
+    import pdfplumber
+    # Build a real minimal PDF bytes using reportlab if available, otherwise use a fixture
+    # We mock pdfplumber.open instead to avoid needing a real PDF in tests.
+    pass
+
+
+class ExtractTextFromPdfTest(TestCase):
+
+    @patch("agents.services.cv_agent.pdfplumber.open")
+    def test_extracts_text_from_pages(self, mock_open):
+        mock_page1 = MagicMock()
+        mock_page1.extract_text.return_value = "Page 1 contenu"
+        mock_page2 = MagicMock()
+        mock_page2.extract_text.return_value = "Page 2 contenu"
+        mock_open.return_value.__enter__.return_value.pages = [mock_page1, mock_page2]
+
+        result = extract_text_from_pdf(b"fake-pdf-bytes")
+        self.assertIn("Page 1 contenu", result)
+        self.assertIn("Page 2 contenu", result)
+
+    @patch("agents.services.cv_agent.pdfplumber.open")
+    def test_raises_on_empty_pdf(self, mock_open):
+        mock_page = MagicMock()
+        mock_page.extract_text.return_value = None
+        mock_open.return_value.__enter__.return_value.pages = [mock_page]
+
+        with self.assertRaises(ClaudeError):
+            extract_text_from_pdf(b"fake-pdf-bytes")
+
+    @patch("agents.services.cv_agent.pdfplumber.open")
+    def test_skips_none_pages(self, mock_open):
+        mock_page1 = MagicMock()
+        mock_page1.extract_text.return_value = None
+        mock_page2 = MagicMock()
+        mock_page2.extract_text.return_value = "Contenu valide"
+        mock_open.return_value.__enter__.return_value.pages = [mock_page1, mock_page2]
+
+        result = extract_text_from_pdf(b"fake-pdf-bytes")
+        self.assertIn("Contenu valide", result)
+
+
+class CvEndpointTest(TestCase):
+
+    def setUp(self):
+        self.client = Client()
+        self.session_id = str(uuid.uuid4())
+
+    def _make_pdf_file(self, name="cv.pdf", content=b"fake-pdf"):
+        return io.BytesIO(content), name
+
+    def _post(self, job_offer, cv_bytes, cv_name="cv.pdf", cover_letter_bytes=None, cover_letter_name="lm.pdf"):
+        data = {
+            "job_offer": job_offer,
+            "session_id": self.session_id,
+            "cv": io.BytesIO(cv_bytes),
+        }
+        data["cv"].name = cv_name
+        if cover_letter_bytes is not None:
+            lm = io.BytesIO(cover_letter_bytes)
+            lm.name = cover_letter_name
+            data["cover_letter"] = lm
+        return self.client.post("/api/agents/cv/", data=data, format="multipart")
+
+    @patch("agents.views.cv_agent_generate")
+    @patch("agents.views.extract_text_from_pdf")
+    def test_returns_sse_stream(self, mock_extract, mock_generate):
+        mock_extract.return_value = "Texte du CV"
+        mock_generate.return_value = iter(["CV adapté"])
+        response = self._post(
+            job_offer="Développeur Python senior avec 5 ans d'expérience en Django.",
+            cv_bytes=b"fake-pdf",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/event-stream")
+
+    @patch("agents.views.cv_agent_generate")
+    @patch("agents.views.extract_text_from_pdf")
+    def test_stream_contains_tokens(self, mock_extract, mock_generate):
+        mock_extract.return_value = "Texte du CV"
+        mock_generate.return_value = iter(["Bonjour", " CV"])
+        response = self._post(
+            job_offer="Développeur Python senior avec 5 ans d'expérience en Django.",
+            cv_bytes=b"fake-pdf",
+        )
+        content = b"".join(response.streaming_content).decode()
+        self.assertIn('"text": "Bonjour"', content)
+        self.assertIn("[DONE]", content)
+
+    @patch("agents.views.cv_agent_generate")
+    @patch("agents.views.extract_text_from_pdf")
+    def test_saves_history_after_stream(self, mock_extract, mock_generate):
+        mock_extract.return_value = "Texte du CV"
+        mock_generate.return_value = iter(["CV généré"])
+        response = self._post(
+            job_offer="Développeur Python senior avec 5 ans d'expérience en Django.",
+            cv_bytes=b"fake-pdf",
+        )
+        b"".join(response.streaming_content)
+        self.assertEqual(GenerationHistory.objects.count(), 1)
+        entry = GenerationHistory.objects.first()
+        self.assertEqual(entry.agent, "cv")
+        self.assertEqual(entry.output, "CV généré")
+
+    @patch("agents.views.cv_agent_generate")
+    @patch("agents.views.extract_text_from_pdf")
+    def test_creates_session_if_not_exists(self, mock_extract, mock_generate):
+        mock_extract.return_value = "Texte du CV"
+        mock_generate.return_value = iter(["ok"])
+        self._post(
+            job_offer="Développeur Python senior avec 5 ans d'expérience en Django.",
+            cv_bytes=b"fake-pdf",
+        )
+        self.assertTrue(Session.objects.filter(id=self.session_id).exists())
+
+    def test_returns_400_on_non_pdf_cv(self):
+        data = {
+            "job_offer": "Développeur Python senior avec 5 ans d'expérience en Django.",
+            "session_id": self.session_id,
+        }
+        f = io.BytesIO(b"not a pdf")
+        f.name = "cv.docx"
+        data["cv"] = f
+        response = self.client.post("/api/agents/cv/", data=data, format="multipart")
+        self.assertEqual(response.status_code, 400)
+
+    def test_returns_400_on_short_job_offer(self):
+        data = {
+            "job_offer": "Trop court",
+            "session_id": self.session_id,
+        }
+        f = io.BytesIO(b"fake-pdf")
+        f.name = "cv.pdf"
+        data["cv"] = f
+        response = self.client.post("/api/agents/cv/", data=data, format="multipart")
+        self.assertEqual(response.status_code, 400)
+
+    def test_returns_400_on_missing_cv(self):
+        data = {
+            "job_offer": "Développeur Python senior avec 5 ans d'expérience en Django.",
+            "session_id": self.session_id,
+        }
+        response = self.client.post("/api/agents/cv/", data=data, format="multipart")
+        self.assertEqual(response.status_code, 400)

--- a/backend/agents/tests/test_linkedin_agent.py
+++ b/backend/agents/tests/test_linkedin_agent.py
@@ -23,14 +23,14 @@ class LinkedInAgentTest(TestCase):
             content_type="application/json",
         )
 
-    @patch("agents.views.generate")
+    @patch("agents.views.linkedin_agent_generate")
     def test_returns_sse_stream(self, mock_generate):
         mock_generate.return_value = iter(["Bonjour", " LinkedIn"])
         response = self._post(self.valid_payload)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "text/event-stream")
 
-    @patch("agents.views.generate")
+    @patch("agents.views.linkedin_agent_generate")
     def test_stream_contains_tokens(self, mock_generate):
         mock_generate.return_value = iter(["Hello", " world"])
         response = self._post(self.valid_payload)
@@ -39,7 +39,7 @@ class LinkedInAgentTest(TestCase):
         self.assertIn('"text": " world"', content)
         self.assertIn("[DONE]", content)
 
-    @patch("agents.views.generate")
+    @patch("agents.views.linkedin_agent_generate")
     def test_saves_history_after_stream(self, mock_generate):
         mock_generate.return_value = iter(["Super post"])
         response = self._post(self.valid_payload)
@@ -49,7 +49,7 @@ class LinkedInAgentTest(TestCase):
         self.assertEqual(entry.agent, "linkedin")
         self.assertEqual(entry.output, "Super post")
 
-    @patch("agents.views.generate")
+    @patch("agents.views.linkedin_agent_generate")
     def test_creates_session_if_not_exists(self, mock_generate):
         mock_generate.return_value = iter(["ok"])
         self._post(self.valid_payload)

--- a/backend/agents/urls.py
+++ b/backend/agents/urls.py
@@ -4,4 +4,5 @@ from . import views
 urlpatterns = [
     path('health/', views.health_check),
     path('agents/linkedin/', views.linkedin_generate),
+    path('agents/cv/', views.cv_generate),
 ]

--- a/backend/agents/views.py
+++ b/backend/agents/views.py
@@ -4,8 +4,9 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
 from .models import Session, GenerationHistory
-from .serializers import LinkedInRequestSerializer
-from .services.linkedin_agent import generate
+from .serializers import LinkedInRequestSerializer, CvRequestSerializer
+from .services.linkedin_agent import generate as linkedin_agent_generate
+from .services.cv_agent import generate as cv_agent_generate, extract_text_from_pdf
 from .services.claude_client import ClaudeError
 
 
@@ -26,7 +27,7 @@ def linkedin_generate(request):
     def event_stream():
         output_chunks = []
         try:
-            for chunk in generate(data['description'], data['tone']):
+            for chunk in linkedin_agent_generate(data['description'], data['tone']):
                 output_chunks.append(chunk)
                 yield f"data: {json.dumps({'text': chunk})}\n\n"
 
@@ -35,6 +36,50 @@ def linkedin_generate(request):
                 session=session,
                 agent="linkedin",
                 input_data={"description": data['description'], "tone": data['tone']},
+                output=full_output,
+            )
+            yield "data: [DONE]\n\n"
+
+        except ClaudeError as e:
+            yield f"data: {json.dumps({'error': str(e)})}\n\n"
+
+    response = StreamingHttpResponse(event_stream(), content_type="text/event-stream")
+    response['Cache-Control'] = 'no-cache'
+    response['X-Accel-Buffering'] = 'no'
+    return response
+
+
+@api_view(['POST'])
+def cv_generate(request):
+    serializer = CvRequestSerializer(data=request.data)
+    if not serializer.is_valid():
+        return Response(serializer.errors, status=400)
+
+    data = serializer.validated_data
+    session, _ = Session.objects.get_or_create(id=data['session_id'])
+
+    try:
+        cv_text = extract_text_from_pdf(data['cv'].read())
+        cover_letter_text = (
+            extract_text_from_pdf(data['cover_letter'].read())
+            if data.get('cover_letter')
+            else ""
+        )
+    except ClaudeError as e:
+        return Response({'error': str(e)}, status=400)
+
+    def event_stream():
+        output_chunks = []
+        try:
+            for chunk in cv_agent_generate(data['job_offer'], cv_text, cover_letter_text):
+                output_chunks.append(chunk)
+                yield f"data: {json.dumps({'text': chunk})}\n\n"
+
+            full_output = "".join(output_chunks)
+            GenerationHistory.objects.create(
+                session=session,
+                agent="cv",
+                input_data={"job_offer": data['job_offer'][:500]},
                 output=full_output,
             )
             yield "data: [DONE]\n\n"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,13 @@ services:
     depends_on:
       - backend
 
+  adminer:
+    image: adminer
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+
 volumes:
   postgres_data:
   media_data:


### PR DESCRIPTION
- CvRequestSerializer: validate PDF type, size (5 Mo max), job offer length
- cv_agent.py: extract_text_from_pdf (in-memory, never persisted) + generate()
- cv_generate view: multipart upload → SSE stream → GenerationHistory saved
- Add adminer service to docker-compose for DB inspection
- Fix views.py import naming conflict (linkedin_agent_generate / cv_agent_generate)
- Update LinkedIn tests to patch renamed import

Closes #17, #18, #19, #20