### PR TITLE
feat: implement CV agent UI with streaming, PDF upload and DOCX download

### DIFF
--- a/backend/agents/services/cv_agent.py
+++ b/backend/agents/services/cv_agent.py
@@ -28,6 +28,12 @@ def generate(job_offer: str, cv_text: str, cover_letter_text: str = ""):
     if cover_letter_text:
         task = """Adapte le CV et la lettre de motivation à cette offre d'emploi.
 
+Pour la lettre de motivation, respecte impérativement cette structure en 4 parties :
+1. Premier paragraphe : présentation du candidat (qui je suis, mon parcours en une phrase).
+2. Deuxième paragraphe : pourquoi cette entreprise — montrer que tu la connais, ce qui t'attire spécifiquement dans ses valeurs, son secteur ou ses projets.
+3. Troisième paragraphe : ce que le candidat peut apporter à l'entreprise via ce poste — compétences concrètes, réalisations pertinentes, valeur ajoutée.
+4. Phrase de clôture élégante et professionnelle (une seule phrase, formule de politesse incluse).
+
 Structure ta réponse ainsi :
 ## CV adapté
 [CV adapté ici]

--- a/frontend/src/components/FileUpload.vue
+++ b/frontend/src/components/FileUpload.vue
@@ -1,3 +1,127 @@
 <template>
-  <div><!-- feat/cv-agent-ui --></div>
+  <div
+    class="file-upload"
+    :class="{ 'file-upload--dragover': dragover, 'file-upload--has-file': modelValue, 'file-upload--error': errorMsg }"
+    @dragover.prevent="dragover = true"
+    @dragleave="dragover = false"
+    @drop.prevent="onDrop"
+    @click="$refs.input.click()"
+  >
+    <input ref="input" type="file" accept=".pdf" hidden @change="onChange" />
+
+    <div v-if="modelValue" class="file-upload__file">
+      <span class="file-upload__filename">{{ modelValue.name }}</span>
+      <button class="file-upload__remove" type="button" @click.stop="clear">×</button>
+    </div>
+    <div v-else class="file-upload__placeholder">
+      <span class="file-upload__label">{{ label }}</span>
+      <span class="file-upload__hint">Glisse un PDF ici ou clique pour choisir</span>
+    </div>
+
+    <p v-if="errorMsg" class="file-upload__error">{{ errorMsg }}</p>
+  </div>
 </template>
+
+<script setup>
+import { ref } from 'vue'
+
+const props = defineProps({
+  modelValue: { type: File, default: null },
+  label: { type: String, default: 'Fichier PDF' },
+})
+const emit = defineEmits(['update:modelValue'])
+
+const dragover = ref(false)
+const errorMsg = ref('')
+
+function validate(file) {
+  if (!file.name.toLowerCase().endsWith('.pdf')) {
+    errorMsg.value = 'Le fichier doit être un PDF.'
+    return false
+  }
+  if (file.size > 5 * 1024 * 1024) {
+    errorMsg.value = 'Le fichier ne doit pas dépasser 5 Mo.'
+    return false
+  }
+  errorMsg.value = ''
+  return true
+}
+
+function onChange(e) {
+  const file = e.target.files[0]
+  if (file && validate(file)) emit('update:modelValue', file)
+  e.target.value = ''
+}
+
+function onDrop(e) {
+  dragover.value = false
+  const file = e.dataTransfer.files[0]
+  if (file && validate(file)) emit('update:modelValue', file)
+}
+
+function clear() {
+  errorMsg.value = ''
+  emit('update:modelValue', null)
+}
+</script>
+
+<style scoped>
+.file-upload {
+  border: 2px dashed #cbd5e1;
+  border-radius: 8px;
+  padding: 1rem;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  min-height: 80px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+.file-upload:hover { border-color: #94a3b8; background: #f8fafc; }
+.file-upload--dragover { border-color: #0ea5e9; background: #f0f9ff; }
+.file-upload--has-file { border-style: solid; border-color: #0ea5e9; background: #f0f9ff; }
+.file-upload--error { border-color: #ef4444; }
+
+.file-upload__placeholder {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.file-upload__label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #374151;
+}
+.file-upload__hint {
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+.file-upload__file {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.file-upload__filename {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #0369a1;
+  word-break: break-all;
+}
+.file-upload__remove {
+  background: none;
+  border: none;
+  color: #64748b;
+  font-size: 1.2rem;
+  cursor: pointer;
+  padding: 0 0.25rem;
+  line-height: 1;
+}
+.file-upload__remove:hover { color: #ef4444; }
+.file-upload__error {
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+  color: #ef4444;
+}
+</style>

--- a/frontend/src/components/ResultCard.vue
+++ b/frontend/src/components/ResultCard.vue
@@ -1,3 +1,163 @@
 <template>
-  <div><!-- feat/cv-agent-ui --></div>
+  <div v-if="props.content || streaming" class="result-card">
+    <div class="result-card__sections" :class="{ 'result-card__sections--two-col': lmContent }">
+      <div class="result-card__section">
+        <div class="result-card__header">
+          <span class="result-card__label">CV adapté</span>
+          <div v-if="cvContent" class="result-card__actions">
+            <button class="result-card__copy" @click="copy(cvContent, 'cv')">
+              {{ copiedKey === 'cv' ? 'Copié !' : 'Copier' }}
+            </button>
+            <button class="result-card__download" @click="download(cvContent, 'cv-adapte')">
+              Télécharger
+            </button>
+          </div>
+        </div>
+        <div class="result-card__body" v-html="renderMd(cvContent)"></div>
+        <div v-if="streaming && !lmContent" class="result-card__cursor">▌</div>
+      </div>
+
+      <div v-if="lmContent" class="result-card__section">
+        <div class="result-card__header">
+          <span class="result-card__label">Lettre de motivation</span>
+          <div class="result-card__actions">
+            <button class="result-card__copy" @click="copy(lmContent, 'lm')">
+              {{ copiedKey === 'lm' ? 'Copié !' : 'Copier' }}
+            </button>
+            <button class="result-card__download" @click="download(lmContent, 'lettre-motivation')">
+              Télécharger
+            </button>
+          </div>
+        </div>
+        <div class="result-card__body" v-html="renderMd(lmContent)"></div>
+        <div v-if="streaming" class="result-card__cursor">▌</div>
+      </div>
+    </div>
+  </div>
 </template>
+
+<script setup>
+import { computed, ref } from 'vue'
+import { marked } from 'marked'
+
+const props = defineProps({
+  content: { type: String, default: '' },
+  streaming: { type: Boolean, default: false },
+})
+
+const CV_HEADER = '## CV adapté'
+const LM_HEADER = '## Lettre de motivation adaptée'
+
+const cvContent = computed(() => {
+  const c = props.content
+  const cvIdx = c.indexOf(CV_HEADER)
+  if (cvIdx === -1) return c.trim()
+  const start = c.indexOf('\n', cvIdx) + 1
+  const lmIdx = c.indexOf(LM_HEADER)
+  const end = lmIdx !== -1 ? lmIdx : c.length
+  return c.slice(start, end).trim()
+})
+
+const lmContent = computed(() => {
+  const c = props.content
+  const lmIdx = c.indexOf(LM_HEADER)
+  if (lmIdx === -1) return ''
+  const start = c.indexOf('\n', lmIdx) + 1
+  return c.slice(start).trim()
+})
+
+function renderMd(text) {
+  return text ? marked.parse(text) : ''
+}
+
+const copiedKey = ref('')
+function copy(text, key) {
+  navigator.clipboard.writeText(text)
+  copiedKey.value = key
+  setTimeout(() => { copiedKey.value = '' }, 2000)
+}
+
+function download(markdownText, filename) {
+  const html = marked.parse(markdownText)
+  const doc = `<html xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns="http://www.w3.org/TR/REC-html40">
+<head><meta charset="utf-8"><style>body{font-family:Arial,sans-serif;font-size:11pt;line-height:1.6;margin:2cm}h1,h2,h3{color:#1e293b}p{margin:0.5em 0}</style></head>
+<body>${html}</body></html>`
+  const blob = new Blob([doc], { type: 'application/msword' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${filename}.doc`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+</script>
+
+<style scoped>
+.result-card {
+  margin-top: 1.5rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+.result-card__sections {
+  display: grid;
+  grid-template-columns: 1fr;
+}
+.result-card__sections--two-col {
+  grid-template-columns: 1fr 1fr;
+}
+.result-card__section {
+  border-right: 1px solid #e2e8f0;
+}
+.result-card__section:last-child { border-right: none; }
+
+.result-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  background: #f8fafc;
+  border-bottom: 1px solid #e2e8f0;
+}
+.result-card__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #64748b;
+}
+.result-card__actions {
+  display: flex;
+  gap: 0.4rem;
+}
+.result-card__copy,
+.result-card__download {
+  font-size: 0.8rem;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 4px;
+  background: white;
+  cursor: pointer;
+}
+.result-card__copy:hover,
+.result-card__download:hover { background: #f1f5f9; }
+.result-card__download { border-color: #0ea5e9; color: #0369a1; }
+.result-card__download:hover { background: #f0f9ff; }
+.result-card__body {
+  padding: 1rem;
+  line-height: 1.7;
+  font-size: 0.9rem;
+}
+.result-card__cursor {
+  padding: 0 1rem 0.5rem;
+  color: #0ea5e9;
+  animation: blink 1s step-end infinite;
+}
+@keyframes blink { 50% { opacity: 0; } }
+
+@media (max-width: 640px) {
+  .result-card__sections--two-col {
+    grid-template-columns: 1fr;
+  }
+  .result-card__section { border-right: none; border-bottom: 1px solid #e2e8f0; }
+  .result-card__section:last-child { border-bottom: none; }
+}
+</style>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -16,6 +16,45 @@ function getSessionId() {
   return id
 }
 
+export async function streamCv({ job_offer, cv, cover_letter, onChunk, onDone, onError }) {
+  const formData = new FormData()
+  formData.append('job_offer', job_offer)
+  formData.append('session_id', getSessionId())
+  formData.append('cv', cv)
+  if (cover_letter) formData.append('cover_letter', cover_letter)
+
+  const response = await fetch('/api/agents/cv/', {
+    method: 'POST',
+    body: formData,
+  })
+
+  if (!response.ok) {
+    const err = await response.json()
+    onError(err)
+    return
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+
+    const lines = decoder.decode(value).split('\n')
+    for (const line of lines) {
+      if (!line.startsWith('data: ')) continue
+      const payload = line.slice(6)
+      if (payload === '[DONE]') { onDone(); return }
+      try {
+        const { text, error } = JSON.parse(payload)
+        if (error) { onError(error); return }
+        if (text) onChunk(text)
+      } catch {}
+    }
+  }
+}
+
 export async function streamLinkedIn({ description, tone, onChunk, onDone, onError }) {
   const response = await fetch('/api/agents/linkedin/', {
     method: 'POST',

--- a/frontend/src/views/CvView.vue
+++ b/frontend/src/views/CvView.vue
@@ -1,6 +1,149 @@
 <template>
-  <div>
-    <h1>CV &amp; Lettre de motivation</h1>
-    <p>À venir — feat/cv-agent-ui</p>
+  <div class="cv-view">
+    <h1 class="cv-view__title">Adaptateur CV & Lettre de motivation</h1>
+
+    <form class="cv-view__form" @submit.prevent="submit">
+      <label class="cv-view__label">Offre d'emploi</label>
+      <textarea
+        v-model="jobOffer"
+        class="cv-view__textarea"
+        placeholder="Colle ici le texte de l'offre d'emploi..."
+        rows="6"
+        :disabled="streaming"
+      />
+
+      <div class="cv-view__uploads">
+        <div class="cv-view__upload-group">
+          <label class="cv-view__label">CV <span class="cv-view__required">*</span></label>
+          <FileUpload v-model="cvFile" label="Ton CV (PDF)" :disabled="streaming" />
+        </div>
+
+        <div class="cv-view__upload-group">
+          <label class="cv-view__label">Lettre de motivation <span class="cv-view__optional">optionnel</span></label>
+          <FileUpload v-model="coverLetterFile" label="Ta lettre de motivation (PDF)" :disabled="streaming" />
+        </div>
+      </div>
+
+      <button
+        class="cv-view__submit"
+        type="submit"
+        :disabled="streaming || !canSubmit"
+      >
+        {{ streaming ? 'Génération en cours...' : 'Adapter mes documents' }}
+      </button>
+    </form>
+
+    <p v-if="error" class="cv-view__error">{{ error }}</p>
+
+    <ResultCard :content="result" :streaming="streaming" />
   </div>
 </template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { streamCv } from '../services/api'
+import FileUpload from '../components/FileUpload.vue'
+import ResultCard from '../components/ResultCard.vue'
+
+const jobOffer = ref('')
+const cvFile = ref(null)
+const coverLetterFile = ref(null)
+const result = ref('')
+const streaming = ref(false)
+const error = ref('')
+
+const canSubmit = computed(() => jobOffer.value.trim().length >= 20 && cvFile.value !== null)
+
+async function submit() {
+  if (!canSubmit.value) return
+  error.value = ''
+  result.value = ''
+  streaming.value = true
+
+  await streamCv({
+    job_offer: jobOffer.value,
+    cv: cvFile.value,
+    cover_letter: coverLetterFile.value,
+    onChunk: (text) => { result.value += text },
+    onDone: () => { streaming.value = false },
+    onError: (err) => {
+      error.value = typeof err === 'string' ? err : (err?.job_offer?.[0] || err?.cv?.[0] || 'Une erreur est survenue.')
+      streaming.value = false
+    },
+  })
+}
+</script>
+
+<style scoped>
+.cv-view {
+  max-width: 860px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+.cv-view__title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 1.5rem;
+  color: #1e293b;
+}
+.cv-view__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.cv-view__label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #374151;
+}
+.cv-view__required { color: #ef4444; }
+.cv-view__optional {
+  font-weight: 400;
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+.cv-view__textarea {
+  padding: 0.75rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  resize: vertical;
+  font-family: inherit;
+}
+.cv-view__textarea:focus {
+  outline: none;
+  border-color: #0ea5e9;
+}
+.cv-view__uploads {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+.cv-view__upload-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.cv-view__submit {
+  padding: 0.75rem;
+  background: #0ea5e9;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.cv-view__submit:hover:not(:disabled) { background: #0284c7; }
+.cv-view__submit:disabled { opacity: 0.6; cursor: not-allowed; }
+.cv-view__error {
+  margin-top: 1rem;
+  color: #ef4444;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 640px) {
+  .cv-view__uploads { grid-template-columns: 1fr; }
+}
+</style>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,6 +6,10 @@ export default defineConfig({
   server: {
     host: '0.0.0.0',
     port: 5173,
+    watch: {
+      usePolling: true,
+      interval: 300,
+    },
     proxy: {
       '/api': {
         target: process.env.BACKEND_URL || 'http://localhost:8000',


### PR DESCRIPTION
- CvView.vue: form with job offer textarea and two PDF upload zones
- FileUpload.vue: drag & drop component with PDF validation (type, 5MB limit)
- ResultCard.vue: two-column CV/LM display with streaming, copy and DOCX download per section
- api.js: streamCv() with FormData + fetch SSE
- cv_agent.py: structured cover letter prompt (intro, company, value, closing)
- vite.config.js: enable polling for HMR on WSL2/Docker