### PR TITLE
Feat/dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ Thumbs.db
 
 # Local
 my_infos/
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,14 +54,15 @@ backend/
 │   ├── models.py       # Session (UUID anonyme), GenerationHistory
 │   ├── serializers.py  # LinkedInRequestSerializer + CvRequestSerializer
 │   ├── views.py        # endpoints DRF + StreamingHttpResponse (SSE)
-│   └── urls.py         # GET /api/health/, POST /api/agents/linkedin/, POST /api/agents/cv/
+│   └── urls.py         # GET /api/health/, POST /api/agents/linkedin/, POST /api/agents/cv/, GET /api/history/
 frontend/
 ├── src/
-│   ├── services/api.js          # Axios (JSON) + streamLinkedIn() + streamCv() (fetch SSE) + getSessionId()
-│   ├── router/index.js          # routes /linkedin et /cv
+│   ├── services/api.js          # Axios (JSON) + streamLinkedIn() + streamCv() (fetch SSE) + getSessionId() + getHistory()
+│   ├── router/index.js          # routes /linkedin, /cv, /history
 │   ├── views/
 │   │   ├── LinkedinView.vue     # formulaire description + sélecteur 3 tons + état streaming
-│   │   └── CvView.vue           # formulaire offre + upload CV/LM PDF + état streaming
+│   │   ├── CvView.vue           # formulaire offre + upload CV/LM PDF + état streaming
+│   │   └── HistoryView.vue      # liste des générations + modal détail (offre + output Markdown + téléchargement CV/LM)
 │   └── components/
 │       ├── PostResult.vue       # rendu Markdown streamé + bouton copier + curseur clignotant
 │       ├── FileUpload.vue       # drag & drop PDF + feedback erreur
@@ -90,7 +91,7 @@ Vue (fetch) → POST /api/agents/linkedin/  (JSON)
 | GET | `/api/health/` | Healthcheck backend |
 | POST | `/api/agents/linkedin/` | Génère un post LinkedIn (SSE) |
 | POST | `/api/agents/cv/` | Adapte CV + LM à une offre (SSE, multipart/form-data) |
-| GET | `/api/history/` | Historique des générations de la session (à venir — Milestone 7 feat/dashboard) |
+| GET | `/api/history/?session_id=<uuid>` | Historique des 20 dernières générations de la session |
 | POST | `/api/agents/cv/?mode=analyze` | Analyse CV/LM : points forts + recommandations (à venir — Milestone 8 feat/cv-analysis) |
 
 ## Décisions clés

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,8 +10,8 @@ feat/linkedin-agent-ui      ✅ terminé
 feat/pdf-handling           ✅ terminé
 feat/cv-agent-api           ✅ terminé
 feat/cv-agent-ui            ✅ terminé
-feat/frontend-design
-feat/dashboard
+feat/frontend-design        ✅ terminé
+feat/dashboard              ✅ terminé
 feat/cv-analysis
 chore/docker-prod
 ```

--- a/backend/agents/serializers.py
+++ b/backend/agents/serializers.py
@@ -1,4 +1,16 @@
 from rest_framework import serializers
+from .models import GenerationHistory
+
+
+class GenerationHistorySerializer(serializers.ModelSerializer):
+    preview = serializers.SerializerMethodField()
+
+    class Meta:
+        model = GenerationHistory
+        fields = ['id', 'agent', 'input_data', 'preview', 'output', 'created_at']
+
+    def get_preview(self, obj):
+        return obj.output[:200].strip()
 
 
 class LinkedInRequestSerializer(serializers.Serializer):

--- a/backend/agents/urls.py
+++ b/backend/agents/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('health/', views.health_check),
     path('agents/linkedin/', views.linkedin_generate),
     path('agents/cv/', views.cv_generate),
+    path('history/', views.history),
 ]

--- a/backend/agents/views.py
+++ b/backend/agents/views.py
@@ -4,7 +4,7 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
 from .models import Session, GenerationHistory
-from .serializers import LinkedInRequestSerializer, CvRequestSerializer
+from .serializers import LinkedInRequestSerializer, CvRequestSerializer, GenerationHistorySerializer
 from .services.linkedin_agent import generate as linkedin_agent_generate
 from .services.cv_agent import generate as cv_agent_generate, extract_text_from_pdf
 from .services.claude_client import ClaudeError
@@ -13,6 +13,20 @@ from .services.claude_client import ClaudeError
 @api_view(['GET'])
 def health_check(request):
     return Response({'status': 'ok'})
+
+
+@api_view(['GET'])
+def history(request):
+    session_id = request.query_params.get('session_id')
+    if not session_id:
+        return Response({'error': 'session_id requis.'}, status=400)
+    try:
+        session = Session.objects.get(id=session_id)
+    except (Session.DoesNotExist, Exception):
+        return Response([], status=200)
+    items = session.history.all()[:20]
+    serializer = GenerationHistorySerializer(items, many=True)
+    return Response(serializer.data)
 
 
 @api_view(['POST'])

--- a/backend/agents/views.py
+++ b/backend/agents/views.py
@@ -93,7 +93,7 @@ def cv_generate(request):
             GenerationHistory.objects.create(
                 session=session,
                 agent="cv",
-                input_data={"job_offer": data['job_offer'][:500]},
+                input_data={"job_offer": data['job_offer']},
                 output=full_output,
             )
             yield "data: [DONE]\n\n"

--- a/frontend/design/careerboost.html
+++ b/frontend/design/careerboost.html
@@ -1,0 +1,471 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=DM+Sans:wght@300;400;600;700&display=swap" rel="stylesheet">
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --cyan: #00E5FF; --violet: #8B5CF6; --pink: #F472B6;
+    --bg: #080B14; --card: #151C2E; --card2: #1C2540;
+    --fh: 'Syne', sans-serif; --fb: 'DM Sans', sans-serif;
+  }
+  html, body {
+    background: #080B14 !important;
+    color: #F0F4FF !important;
+    font-family: 'DM Sans', sans-serif;
+    min-height: 100vh;
+  }
+
+  .bg-mesh { position: fixed; inset: 0; z-index: 0; pointer-events: none; }
+  .blob { position: absolute; border-radius: 50%; filter: blur(120px); opacity: 0.09; }
+  .b1 { width: 600px; height: 600px; background: #8B5CF6; top: -200px; right: -100px; animation: d1 12s ease-in-out infinite; }
+  .b2 { width: 500px; height: 500px; background: #00E5FF; bottom: -100px; left: -150px; animation: d2 15s ease-in-out infinite; }
+  .b3 { width: 280px; height: 280px; background: #F472B6; top: 40%; left: 32%; animation: d3 10s ease-in-out infinite; }
+  @keyframes d1 { 0%,100%{transform:translate(0,0)} 50%{transform:translate(-35px,25px)} }
+  @keyframes d2 { 0%,100%{transform:translate(0,0)} 50%{transform:translate(30px,-35px)} }
+  @keyframes d3 { 0%,100%{transform:translate(0,0)} 50%{transform:translate(-18px,18px)} }
+
+  header {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 10;
+    padding: 16px 40px; display: flex; align-items: center; justify-content: space-between;
+    border-bottom: 1px solid rgba(255,255,255,0.1);
+    backdrop-filter: blur(20px);
+    background: rgba(8,11,20,0.92) !important;
+  }
+  .logo { font-family: 'Syne', sans-serif; font-size: 17px; font-weight: 800; display: flex; align-items: center; gap: 10px; color: #F0F4FF !important; }
+  .logo-icon { width: 30px; height: 30px; border-radius: 8px; background: linear-gradient(135deg, #00E5FF, #8B5CF6); display: flex; align-items: center; justify-content: center; font-size: 15px; }
+  .logo .accent { color: #00E5FF !important; }
+
+  nav { display: flex; gap: 3px; background: rgba(255,255,255,0.05) !important; border: 1px solid rgba(255,255,255,0.1); border-radius: 100px; padding: 4px; }
+  .nav-btn {
+    background: transparent !important;
+    border: none !important;
+    color: #8B95B0 !important;
+    font-family: 'DM Sans', sans-serif; font-size: 13px; font-weight: 600;
+    padding: 7px 16px; border-radius: 100px; cursor: pointer; transition: all 0.2s;
+  }
+  .nav-btn:hover { color: #ffffff !important; background: rgba(255,255,255,0.08) !important; }
+  .nav-btn.active { background: rgba(0,229,255,0.15) !important; color: #00E5FF !important; border: 1px solid rgba(0,229,255,0.3) !important; }
+
+  main { position: relative; z-index: 5; padding-top: 88px; min-height: 100vh; background: transparent !important; }
+  .page { display: none; animation: fi 0.35s ease; }
+  .page.active { display: block; }
+  @keyframes fi { from{opacity:0;transform:translateY(10px)} to{opacity:1;transform:translateY(0)} }
+
+  .container { max-width: 780px; margin: 0 auto; padding: 50px 40px; }
+
+  .page-badge { display: inline-flex; align-items: center; gap: 8px; background: rgba(0,229,255,0.08) !important; border: 1px solid rgba(0,229,255,0.2); border-radius: 100px; padding: 5px 13px; font-size: 11px; font-weight: 600; color: #00E5FF !important; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 20px; }
+  .badge-dot { width: 5px; height: 5px; border-radius: 50%; background: #00E5FF; animation: pu 2s infinite; }
+  @keyframes pu { 0%,100%{opacity:1} 50%{opacity:0.3} }
+
+  h1 { font-family: 'Syne', sans-serif; font-size: clamp(28px,4vw,44px); font-weight: 800; line-height: 1.1; letter-spacing: -1.5px; margin-bottom: 10px; color: #ffffff !important; }
+  h1 span { color: #00E5FF !important; }
+  .subtitle { color: #8B95B0 !important; font-size: 15px; font-weight: 300; line-height: 1.6; margin-bottom: 40px; }
+  .subtitle strong { color: #C5CEDE !important; font-weight: 500; }
+
+  .field { margin-bottom: 24px; }
+  label { display: block; font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: #7B85A0 !important; margin-bottom: 9px; }
+
+  textarea {
+    width: 100%;
+    background: #151C2E !important;
+    border: 1px solid rgba(255,255,255,0.12) !important;
+    border-radius: 14px;
+    color: #E8EEF8 !important;
+    font-family: 'DM Sans', sans-serif; font-size: 14px; font-weight: 300; line-height: 1.7;
+    padding: 16px 18px; resize: none; transition: border-color 0.2s, box-shadow 0.2s;
+  }
+  textarea::placeholder { color: rgba(139,149,176,0.5) !important; }
+  textarea:focus { outline: none; border-color: rgba(0,229,255,0.45) !important; box-shadow: 0 0 0 3px rgba(0,229,255,0.07); }
+
+  /* ── TONE BUTTONS : texte blanc, survol fond blanc + texte noir ── */
+  .tone-grid { display: flex; gap: 10px; }
+  .tone-btn {
+    flex: 1;
+    background: #1C2540 !important;
+    border: 2px solid rgba(255,255,255,0.22) !important;
+    border-radius: 14px;
+    color: #FFFFFF !important;
+    font-family: 'DM Sans', sans-serif;
+    font-size: 14px; font-weight: 700;
+    padding: 18px 10px;
+    cursor: pointer;
+    transition: all 0.22s;
+  }
+  .tone-btn:hover {
+    background: #FFFFFF !important;
+    border-color: #FFFFFF !important;
+    color: #080B14 !important;
+  }
+  .tone-btn.active {
+    background: rgba(0,229,255,0.15) !important;
+    border: 2px solid #00E5FF !important;
+    color: #00E5FF !important;
+    box-shadow: 0 0 22px rgba(0,229,255,0.12);
+  }
+  .tone-btn.active:hover {
+    background: #FFFFFF !important;
+    border-color: #FFFFFF !important;
+    color: #080B14 !important;
+  }
+  .tone-icon { display: block; font-size: 22px; margin-bottom: 8px; }
+
+  .cta-btn {
+    width: 100%;
+    background: linear-gradient(135deg, #00C8E0, #7C3AED) !important;
+    border: none !important; border-radius: 14px;
+    color: #ffffff !important;
+    font-family: 'Syne', sans-serif; font-size: 16px; font-weight: 700; letter-spacing: 0.03em;
+    padding: 18px; cursor: pointer; transition: all 0.25s;
+    box-shadow: 0 4px 24px rgba(0,200,224,0.18);
+  }
+  .cta-btn:hover { transform: translateY(-2px); box-shadow: 0 14px 40px rgba(0,200,224,0.35); filter: brightness(1.1); }
+  .cta-btn:active { transform: translateY(0); }
+
+  .drop-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-bottom: 24px; }
+  .drop-zone {
+    background: #1C2540 !important;
+    border: 2px dashed rgba(255,255,255,0.18) !important;
+    border-radius: 14px; padding: 28px 16px; text-align: center; cursor: pointer; position: relative; transition: all 0.22s;
+  }
+  .drop-zone:hover { border-color: rgba(0,229,255,0.5) !important; background: #1A2D50 !important; }
+  .drop-zone.has-file { border-style: solid !important; border-color: #00E5FF !important; background: rgba(0,229,255,0.05) !important; }
+  .drop-zone input[type=file] { position: absolute; inset: 0; opacity: 0; cursor: pointer; }
+  .drop-icon { font-size: 26px; margin-bottom: 8px; display: block; }
+  .drop-label { font-family: 'Syne', sans-serif; font-size: 13px; font-weight: 700; color: #D8E0F0 !important; margin-bottom: 4px; }
+  .drop-hint { font-size: 11px; color: #8B95B0 !important; }
+
+  .output-card { display: none; margin-top: 28px; background: #151C2E !important; border: 1px solid rgba(0,229,255,0.22) !important; border-radius: 18px; overflow: hidden; animation: fi 0.4s ease; }
+  .output-card.visible { display: block; }
+  .output-header { display: flex; align-items: center; justify-content: space-between; padding: 14px 18px; background: rgba(0,229,255,0.06) !important; border-bottom: 1px solid rgba(255,255,255,0.07); }
+  .output-title { font-family: 'Syne', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: #00E5FF !important; }
+  .copy-btn { background: rgba(255,255,255,0.09) !important; border: 1px solid rgba(255,255,255,0.2) !important; border-radius: 8px; color: #ffffff !important; font-family: 'DM Sans', sans-serif; font-size: 12px; font-weight: 600; padding: 5px 13px; cursor: pointer; transition: all 0.2s; }
+  .copy-btn:hover { background: rgba(0,229,255,0.18) !important; color: #00E5FF !important; border-color: rgba(0,229,255,0.4) !important; }
+  .output-body { padding: 22px; font-size: 14px; line-height: 1.85; color: #C9D1E0 !important; white-space: pre-wrap; }
+
+  .spinner { display: none; align-items: center; justify-content: center; gap: 12px; padding: 28px; color: #8B95B0 !important; font-size: 14px; }
+  .spinner.visible { display: flex; }
+  .spin { width: 18px; height: 18px; border: 2px solid rgba(0,229,255,0.15); border-top-color: #00E5FF; border-radius: 50%; animation: sp 0.7s linear infinite; }
+  @keyframes sp { to { transform: rotate(360deg); } }
+
+  /* DASHBOARD */
+  .dash-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 14px; margin-bottom: 32px; }
+  .stat-card { background: #151C2E !important; border: 1px solid rgba(255,255,255,0.08) !important; border-radius: 16px; padding: 22px 20px; position: relative; overflow: hidden; transition: border-color 0.22s, transform 0.22s; }
+  .stat-card:hover { transform: translateY(-3px); }
+  .stat-card.s-cyan:hover { border-color: rgba(0,229,255,0.35) !important; }
+  .stat-card.s-violet:hover { border-color: rgba(139,92,246,0.35) !important; }
+  .stat-card.s-pink:hover { border-color: rgba(244,114,182,0.35) !important; }
+  .stat-card::before { content:''; position:absolute; top:0; left:0; right:0; height:2px; }
+  .s-cyan::before { background: linear-gradient(90deg,#00E5FF,transparent); }
+  .s-violet::before { background: linear-gradient(90deg,#8B5CF6,transparent); }
+  .s-pink::before { background: linear-gradient(90deg,#F472B6,transparent); }
+  .stat-label { font-size: 11px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: #6B7590 !important; margin-bottom: 10px; }
+  .stat-value { font-family: 'Syne',sans-serif; font-size: 38px; font-weight: 800; line-height: 1; margin-bottom: 6px; }
+  .c-cyan { color: #00E5FF !important; } .c-violet { color: #8B5CF6 !important; } .c-pink { color: #F472B6 !important; }
+  .stat-sub { font-size: 12px; color: #6B7590 !important; }
+  .stat-trend { display: inline-flex; align-items: center; gap: 4px; font-size: 11px; font-weight: 600; color: #4ADE80 !important; margin-top: 4px; }
+
+  .sec-title { font-family: 'Syne',sans-serif; font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: #6B7590 !important; margin: 30px 0 13px; }
+
+  .activity-list { display: flex; flex-direction: column; gap: 9px; margin-bottom: 28px; }
+  .act-item { background: #151C2E !important; border: 1px solid rgba(255,255,255,0.07) !important; border-radius: 12px; padding: 13px 16px; display: flex; align-items: center; gap: 13px; transition: border-color 0.2s, background 0.2s; }
+  .act-item:hover { background: #1A2238 !important; border-color: rgba(255,255,255,0.14) !important; }
+  .act-ico { width: 36px; height: 36px; border-radius: 10px; display: flex; align-items: center; justify-content: center; font-size: 16px; flex-shrink: 0; }
+  .act-ico.li { background: rgba(0,229,255,0.1) !important; }
+  .act-ico.cv { background: rgba(139,92,246,0.12) !important; }
+  .act-meta { flex: 1; }
+  .act-title { font-size: 13px; font-weight: 600; color: #D8E0F0 !important; margin-bottom: 3px; }
+  .act-date { font-size: 11px; color: #6B7590 !important; }
+  .act-badge { font-size: 11px; font-weight: 600; padding: 3px 10px; border-radius: 20px; white-space: nowrap; }
+  .done { background: rgba(74,222,128,0.1) !important; color: #4ADE80 !important; border: 1px solid rgba(74,222,128,0.2); }
+  .pend { background: rgba(250,204,21,0.08) !important; color: #FACC15 !important; border: 1px solid rgba(250,204,21,0.2); }
+
+  .tips-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+  .tip-card { background: #1C2540 !important; border: 1px solid rgba(255,255,255,0.07) !important; border-radius: 14px; padding: 18px; transition: border-color 0.22s, background 0.22s; }
+  .tip-card:hover { background: #202C4A !important; border-color: rgba(0,229,255,0.2) !important; }
+  .tip-ico { font-size: 20px; margin-bottom: 9px; display: block; }
+  .tip-title { font-family: 'Syne',sans-serif; font-size: 13px; font-weight: 700; color: #D8E0F0 !important; margin-bottom: 5px; }
+  .tip-text { font-size: 12px; color: #6B7590 !important; line-height: 1.6; }
+
+  @media(max-width:620px){
+    header{padding:14px 16px;}
+    .container{padding:36px 18px;}
+    .tone-grid,.tips-grid,.drop-grid{grid-template-columns:1fr;}
+    .dash-grid{grid-template-columns:1fr 1fr;}
+    .nav-btn{padding:6px 10px;font-size:12px;}
+  }
+</style>
+</head>
+<body>
+
+<div class="bg-mesh">
+  <div class="blob b1"></div>
+  <div class="blob b2"></div>
+  <div class="blob b3"></div>
+</div>
+
+<header>
+  <div class="logo">
+    <div class="logo-icon">🚀</div>
+    Career<span class="accent">Boost</span>&nbsp;IA
+  </div>
+  <nav>
+    <button class="nav-btn active" onclick="showPage('linkedin',this)">LinkedIn Post</button>
+    <button class="nav-btn" onclick="showPage('cv',this)">CV & Lettre</button>
+    <button class="nav-btn" onclick="showPage('dashboard',this)">Dashboard</button>
+  </nav>
+</header>
+
+<main>
+
+  <!-- LINKEDIN -->
+  <div class="page active" id="page-linkedin">
+    <div class="container">
+      <div class="page-badge"><span class="badge-dot"></span> Agent IA</div>
+      <h1>Génère ton post<br><span>LinkedIn parfait</span></h1>
+      <p class="subtitle">Décris ton idée, choisis le ton — <strong>ton agent IA fait le reste.</strong></p>
+      <div class="field">
+        <label>Ton idée</label>
+        <textarea id="li-desc" rows="6" placeholder="Ex : J'ai lancé un side project en 3 semaines, voici ce que j'ai appris…"></textarea>
+      </div>
+      <div class="field">
+        <label>Ton</label>
+        <div class="tone-grid">
+          <button class="tone-btn active" data-tone="professionnel" onclick="setTone(this)">
+            <span class="tone-icon">🎯</span>Professionnel
+          </button>
+          <button class="tone-btn" data-tone="storytelling" onclick="setTone(this)">
+            <span class="tone-icon">✨</span>Storytelling
+          </button>
+          <button class="tone-btn" data-tone="technique" onclick="setTone(this)">
+            <span class="tone-icon">⚙️</span>Technique
+          </button>
+        </div>
+      </div>
+      <button class="cta-btn" onclick="generateLinkedin()">Générer le post →</button>
+      <div class="spinner" id="li-spinner"><div class="spin"></div><span>Ton agent IA rédige…</span></div>
+      <div class="output-card" id="li-output">
+        <div class="output-header">
+          <span class="output-title">Post LinkedIn</span>
+          <button class="copy-btn" onclick="copyOutput('li-body',this)">Copier</button>
+        </div>
+        <div class="output-body" id="li-body"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- CV -->
+  <div class="page" id="page-cv">
+    <div class="container">
+      <div class="page-badge"><span class="badge-dot"></span> Agent IA</div>
+      <h1>Adapte ton CV &<br><span>ta lettre</span></h1>
+      <p class="subtitle">Colle l'offre d'emploi, dépose tes documents — <strong>ton agent IA fait le reste.</strong></p>
+      <div class="field">
+        <label>Offre d'emploi</label>
+        <textarea id="cv-offer" rows="6" placeholder="Colle ici le texte de l'offre d'emploi…"></textarea>
+      </div>
+      <div class="drop-grid">
+        <div>
+          <label>CV <span style="color:#F472B6;font-size:10px;letter-spacing:0.06em;font-weight:700;margin-left:4px;">REQUIS</span></label>
+          <div class="drop-zone" id="cv-drop">
+            <input type="file" accept=".pdf" onchange="fileSelected(this,'cv-drop','cv-name')">
+            <span class="drop-icon">📄</span>
+            <div class="drop-label">Ton CV (PDF)</div>
+            <div class="drop-hint" id="cv-name">Glisse ou clique pour choisir</div>
+          </div>
+        </div>
+        <div>
+          <label>Lettre <span style="color:#6B7590;font-size:10px;letter-spacing:0.06em;font-weight:600;margin-left:4px;">OPTIONNEL</span></label>
+          <div class="drop-zone" id="lm-drop">
+            <input type="file" accept=".pdf" onchange="fileSelected(this,'lm-drop','lm-name')">
+            <span class="drop-icon">✉️</span>
+            <div class="drop-label">Ta lettre de motivation (PDF)</div>
+            <div class="drop-hint" id="lm-name">Glisse ou clique pour choisir</div>
+          </div>
+        </div>
+      </div>
+      <button class="cta-btn" onclick="generateCV()">Adapter mes documents →</button>
+      <div class="spinner" id="cv-spinner"><div class="spin"></div><span>Ton agent IA analyse…</span></div>
+      <div class="output-card" id="cv-output">
+        <div class="output-header">
+          <span class="output-title">Recommandations</span>
+          <button class="copy-btn" onclick="copyOutput('cv-body',this)">Copier</button>
+        </div>
+        <div class="output-body" id="cv-body"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- DASHBOARD -->
+  <div class="page" id="page-dashboard">
+    <div class="container">
+      <div class="page-badge"><span class="badge-dot"></span> Vue d'ensemble</div>
+      <h1>Ton espace<br><span>CareerBoost</span></h1>
+      <p class="subtitle">Suis tes générations et optimise ta stratégie — <strong>ton agent IA t'accompagne.</strong></p>
+      <div class="dash-grid">
+        <div class="stat-card s-cyan">
+          <div class="stat-label">Posts générés</div>
+          <div class="stat-value c-cyan">12</div>
+          <div class="stat-trend">↑ +3 cette semaine</div>
+        </div>
+        <div class="stat-card s-violet">
+          <div class="stat-label">CV adaptés</div>
+          <div class="stat-value c-violet">5</div>
+          <div class="stat-sub">sur 8 offres ciblées</div>
+        </div>
+        <div class="stat-card s-pink">
+          <div class="stat-label">Lettres rédigées</div>
+          <div class="stat-value c-pink">4</div>
+          <div class="stat-trend">↑ +1 ce mois</div>
+        </div>
+      </div>
+      <div class="sec-title">Activité récente</div>
+      <div class="activity-list">
+        <div class="act-item"><div class="act-ico li">💼</div><div class="act-meta"><div class="act-title">Post LinkedIn — Lancement side project</div><div class="act-date">Aujourd'hui · Ton Storytelling</div></div><span class="act-badge done">Généré</span></div>
+        <div class="act-item"><div class="act-ico cv">📄</div><div class="act-meta"><div class="act-title">CV adapté — Offre Product Manager</div><div class="act-date">Hier · 6 recommandations</div></div><span class="act-badge done">Adapté</span></div>
+        <div class="act-item"><div class="act-ico li">✨</div><div class="act-meta"><div class="act-title">Post LinkedIn — Retour d'expérience remote</div><div class="act-date">Il y a 3 jours · Ton Professionnel</div></div><span class="act-badge done">Généré</span></div>
+        <div class="act-item"><div class="act-ico cv">✉️</div><div class="act-meta"><div class="act-title">Lettre — Startup Fintech Paris</div><div class="act-date">Il y a 5 jours</div></div><span class="act-badge pend">En cours</span></div>
+      </div>
+      <div class="sec-title">Conseils de l'agent IA</div>
+      <div class="tips-grid">
+        <div class="tip-card"><span class="tip-ico">📈</span><div class="tip-title">Poste 2× par semaine</div><div class="tip-text">La régularité sur LinkedIn booste ta visibilité de 3× selon l'algorithme.</div></div>
+        <div class="tip-card"><span class="tip-ico">🎯</span><div class="tip-title">Personnalise chaque CV</div><div class="tip-text">Un CV adapté à l'offre multiplie tes chances de décrocher un entretien.</div></div>
+        <div class="tip-card"><span class="tip-ico">🔑</span><div class="tip-title">Mots-clés ATS</div><div class="tip-text">80% des CV sont filtrés par des logiciels avant d'atteindre un recruteur.</div></div>
+        <div class="tip-card"><span class="tip-ico">💬</span><div class="tip-title">Engage ta communauté</div><div class="tip-text">Réponds aux commentaires dans la 1ère heure pour maximiser la portée.</div></div>
+      </div>
+    </div>
+  </div>
+
+</main>
+
+<script>
+let currentTone = 'professionnel';
+
+function showPage(name, btn) {
+  document.querySelectorAll('.page').forEach(p => p.classList.remove('active'));
+  document.querySelectorAll('.nav-btn').forEach(b => b.classList.remove('active'));
+  document.getElementById('page-' + name).classList.add('active');
+  btn.classList.add('active');
+}
+
+function setTone(btn) {
+  document.querySelectorAll('.tone-btn').forEach(b => b.classList.remove('active'));
+  btn.classList.add('active');
+  currentTone = btn.dataset.tone;
+}
+
+function fileSelected(input, dropId, nameId) {
+  const file = input.files[0];
+  if (!file) return;
+  document.getElementById(dropId).classList.add('has-file');
+  document.getElementById(nameId).textContent = '✓ ' + file.name;
+}
+
+// Force dark colors via JS to override any iframe defaults
+document.querySelectorAll('.tone-btn').forEach(btn => {
+  btn.addEventListener('mouseenter', () => {
+    btn.style.background = '#FFFFFF';
+    btn.style.color = '#080B14';
+    btn.style.borderColor = '#FFFFFF';
+  });
+  btn.addEventListener('mouseleave', () => {
+    if (btn.classList.contains('active')) {
+      btn.style.background = 'rgba(0,229,255,0.15)';
+      btn.style.color = '#00E5FF';
+      btn.style.borderColor = '#00E5FF';
+    } else {
+      btn.style.background = '#1C2540';
+      btn.style.color = '#FFFFFF';
+      btn.style.borderColor = 'rgba(255,255,255,0.22)';
+    }
+  });
+});
+
+function setTone(btn) {
+  document.querySelectorAll('.tone-btn').forEach(b => {
+    b.classList.remove('active');
+    b.style.background = '#1C2540';
+    b.style.color = '#FFFFFF';
+    b.style.borderColor = 'rgba(255,255,255,0.22)';
+  });
+  btn.classList.add('active');
+  btn.style.background = 'rgba(0,229,255,0.15)';
+  btn.style.color = '#00E5FF';
+  btn.style.borderColor = '#00E5FF';
+  currentTone = btn.dataset.tone;
+}
+
+// Init tone btn colors on load
+document.querySelectorAll('.tone-btn').forEach(btn => {
+  if (btn.classList.contains('active')) {
+    btn.style.background = 'rgba(0,229,255,0.15)';
+    btn.style.color = '#00E5FF';
+    btn.style.borderColor = '#00E5FF';
+  } else {
+    btn.style.background = '#1C2540';
+    btn.style.color = '#FFFFFF';
+    btn.style.borderColor = 'rgba(255,255,255,0.22)';
+  }
+});
+
+async function generateLinkedin() {
+  const desc = document.getElementById('li-desc').value.trim();
+  if (!desc) { alert('Décris ton idée d\'abord !'); return; }
+  const spinner = document.getElementById('li-spinner');
+  const output = document.getElementById('li-output');
+  const body = document.getElementById('li-body');
+  spinner.classList.add('visible'); output.classList.remove('visible');
+  const toneMap = {
+    professionnel: 'professionnel et inspirant, avec des chiffres ou apprentissages concrets',
+    storytelling: 'narratif et émotionnel, avec une accroche forte et une chute percutante',
+    technique: 'précis et technique, avec des détails concrets et des termes du secteur'
+  };
+  try {
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'claude-sonnet-4-20250514', max_tokens: 1000,
+        messages: [{ role: 'user', content: `Tu es expert en personal branding LinkedIn. Génère un post LinkedIn ${toneMap[currentTone]}.\n\nSujet : ${desc}\n\nRègles :\n- Commence par une accroche forte\n- 3 à 5 paragraphes courts\n- Termine par un call-to-action\n- 3 à 5 hashtags\n- Environ 200-300 mots, ton naturel\n\nGénère uniquement le post.` }] })
+    });
+    const data = await res.json();
+    body.textContent = data.content[0].text;
+    output.classList.add('visible');
+  } catch(e) {
+    body.textContent = 'Une erreur est survenue.';
+    output.classList.add('visible');
+  }
+  spinner.classList.remove('visible');
+}
+
+async function generateCV() {
+  const offer = document.getElementById('cv-offer').value.trim();
+  if (!offer) { alert('Colle l\'offre d\'abord !'); return; }
+  const spinner = document.getElementById('cv-spinner');
+  const output = document.getElementById('cv-output');
+  const body = document.getElementById('cv-body');
+  spinner.classList.add('visible'); output.classList.remove('visible');
+  try {
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'claude-sonnet-4-20250514', max_tokens: 1000,
+        messages: [{ role: 'user', content: `Tu es expert en recrutement. Analyse cette offre et donne des recommandations pour optimiser un CV et une lettre.\n\nOffre :\n${offer}\n\nFournis :\n1. Les 5 mots-clés essentiels\n2. Compétences à mettre en avant\n3. Structure de CV recommandée\n4. Conseils pour la lettre\n5. Une phrase d'accroche percutante\n\nSois concis et actionnable.` }] })
+    });
+    const data = await res.json();
+    body.textContent = data.content[0].text;
+    output.classList.add('visible');
+  } catch(e) {
+    body.textContent = 'Une erreur est survenue.';
+    output.classList.add('visible');
+  }
+  spinner.classList.remove('visible');
+}
+
+function copyOutput(id, btn) {
+  navigator.clipboard.writeText(document.getElementById(id).textContent).then(() => {
+    btn.textContent = 'Copié ✓';
+    setTimeout(() => btn.textContent = 'Copier', 2000);
+  });
+}
+</script>
+</body>
+</html>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,6 +3,8 @@
     <router-link to="/linkedin">LinkedIn Post</router-link>
     |
     <router-link to="/cv">CV &amp; Lettre</router-link>
+    |
+    <router-link to="/history">Historique</router-link>
   </nav>
   <router-view />
 </template>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import LinkedinView from '../views/LinkedinView.vue'
 import CvView from '../views/CvView.vue'
+import HistoryView from '../views/HistoryView.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -8,6 +9,7 @@ const router = createRouter({
     { path: '/', redirect: '/linkedin' },
     { path: '/linkedin', component: LinkedinView },
     { path: '/cv', component: CvView },
+    { path: '/history', component: HistoryView },
   ],
 })
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -55,6 +55,12 @@ export async function streamCv({ job_offer, cv, cover_letter, onChunk, onDone, o
   }
 }
 
+export async function getHistory() {
+  const sessionId = getSessionId()
+  const response = await api.get(`/history/?session_id=${sessionId}`)
+  return response.data
+}
+
 export async function streamLinkedIn({ description, tone, onChunk, onDone, onError }) {
   const response = await fetch('/api/agents/linkedin/', {
     method: 'POST',

--- a/frontend/src/views/HistoryView.vue
+++ b/frontend/src/views/HistoryView.vue
@@ -32,7 +32,11 @@
         </div>
         <div class="item-right">
           <span class="item-badge">Généré</span>
-          <button class="dl-btn" @click.stop="download(item)">Télécharger</button>
+          <template v-if="item.agent === 'cv'">
+            <button class="dl-btn" @click.stop="downloadPart(cvContent(item.output), 'cv-adapte')">CV</button>
+            <button v-if="lmContent(item.output)" class="dl-btn" @click.stop="downloadPart(lmContent(item.output), 'lettre-motivation')">LM</button>
+          </template>
+          <button v-else class="dl-btn" @click.stop="downloadPart(item.output, 'post-linkedin')">Télécharger</button>
         </div>
       </div>
     </div>
@@ -55,12 +59,16 @@
           </div>
           <div class="modal-actions">
             <button class="copy-btn" @click="copy(selected.output)">{{ copied ? 'Copié ✓' : 'Copier' }}</button>
-            <button class="dl-btn" @click="download(selected)">Télécharger</button>
+            <template v-if="selected.agent === 'cv'">
+              <button class="dl-btn" @click="downloadPart(cvContent(selected.output), 'cv-adapte')">CV</button>
+              <button v-if="lmContent(selected.output)" class="dl-btn" @click="downloadPart(lmContent(selected.output), 'lettre-motivation')">LM</button>
+            </template>
+            <button v-else class="dl-btn" @click="downloadPart(selected.output, 'post-linkedin')">Télécharger</button>
             <button class="close-btn" @click="close">✕</button>
           </div>
         </div>
         <div class="modal-body">
-          <div v-if="selected.agent === 'cv' && selected.input_data.job_offer" class="modal-offer">
+          <div v-if="selected.input_data?.job_offer" class="modal-offer">
             <div class="modal-offer-label">Offre d'emploi</div>
             <div class="modal-offer-text">{{ selected.input_data.job_offer }}</div>
           </div>
@@ -84,6 +92,7 @@ const copied = ref(false)
 onMounted(async () => {
   try {
     items.value = await getHistory()
+    console.log('[history]', JSON.stringify(items.value.map(i => ({ agent: i.agent, input_data: i.input_data }))))
   } finally {
     loading.value = false
   }
@@ -105,6 +114,23 @@ function formatDate(iso) {
   })
 }
 
+const CV_HEADER = '## CV adapté'
+const LM_HEADER = '## Lettre de motivation adaptée'
+
+function cvContent(output) {
+  const cvIdx = output.indexOf(CV_HEADER)
+  if (cvIdx === -1) return output.trim()
+  const start = output.indexOf('\n', cvIdx) + 1
+  const lmIdx = output.indexOf(LM_HEADER)
+  return output.slice(start, lmIdx !== -1 ? lmIdx : output.length).trim()
+}
+
+function lmContent(output) {
+  const lmIdx = output.indexOf(LM_HEADER)
+  if (lmIdx === -1) return ''
+  return output.slice(output.indexOf('\n', lmIdx) + 1).trim()
+}
+
 function renderMd(text) {
   return text ? marked.parse(text) : ''
 }
@@ -115,9 +141,8 @@ function copy(text) {
   setTimeout(() => { copied.value = false }, 2000)
 }
 
-function download(item) {
-  const html = marked.parse(item.output)
-  const filename = item.agent === 'linkedin' ? 'post-linkedin' : 'cv-adapte'
+function downloadPart(text, filename) {
+  const html = marked.parse(text)
   const doc = `<html xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns="http://www.w3.org/TR/REC-html40">
 <head><meta charset="utf-8"><style>body{font-family:Arial,sans-serif;font-size:11pt;line-height:1.6;margin:2cm}h1,h2,h3{color:#1e293b}p{margin:0.5em 0}</style></head>
 <body>${html}</body></html>`

--- a/frontend/src/views/HistoryView.vue
+++ b/frontend/src/views/HistoryView.vue
@@ -1,0 +1,234 @@
+<template>
+  <div class="container">
+    <div class="page-badge"><span class="badge-dot"></span> Historique</div>
+    <h1>Tes <span>générations</span></h1>
+    <p class="subtitle">Retrouve tes posts et documents générés lors de cette session.</p>
+
+    <div v-if="loading" class="spinner">
+      <div class="spin"></div>
+      <span>Chargement…</span>
+    </div>
+
+    <div v-else-if="items.length === 0" class="empty">
+      <span class="empty-icon">📭</span>
+      <p>Aucune génération pour cette session.</p>
+    </div>
+
+    <div v-else class="list">
+      <div v-for="item in items" :key="item.id" class="item">
+        <div class="item-left">
+          <div class="item-ico" :class="item.agent === 'linkedin' ? 'item-ico--li' : 'item-ico--cv'">
+            {{ item.agent === 'linkedin' ? '💼' : '📄' }}
+          </div>
+          <div class="item-meta">
+            <div class="item-title">
+              {{ item.agent === 'linkedin'
+                ? `Post LinkedIn — ton ${item.input_data.tone}`
+                : `CV adapté — ${item.input_data.job_offer?.slice(0, 50)}…` }}
+            </div>
+            <div class="item-date">{{ formatDate(item.created_at) }}</div>
+          </div>
+        </div>
+        <div class="item-right">
+          <span class="item-badge">Généré</span>
+          <button class="dl-btn" @click="download(item)">Télécharger</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { marked } from 'marked'
+import { getHistory } from '../services/api'
+
+const items = ref([])
+const loading = ref(true)
+
+onMounted(async () => {
+  try {
+    items.value = await getHistory()
+  } finally {
+    loading.value = false
+  }
+})
+
+function formatDate(iso) {
+  return new Date(iso).toLocaleDateString('fr-FR', {
+    day: 'numeric', month: 'short', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  })
+}
+
+function download(item) {
+  const html = marked.parse(item.output)
+  const filename = item.agent === 'linkedin' ? 'post-linkedin' : 'cv-adapte'
+  const doc = `<html xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns="http://www.w3.org/TR/REC-html40">
+<head><meta charset="utf-8"><style>body{font-family:Arial,sans-serif;font-size:11pt;line-height:1.6;margin:2cm}h1,h2,h3{color:#1e293b}p{margin:0.5em 0}</style></head>
+<body>${html}</body></html>`
+  const blob = new Blob([doc], { type: 'application/msword' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${filename}.doc`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+</script>
+
+<style scoped>
+.container {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 50px 40px;
+}
+
+.page-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(139,92,246,0.08);
+  border: 1px solid rgba(139,92,246,0.2);
+  border-radius: 100px;
+  padding: 5px 13px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--violet);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 20px;
+}
+.badge-dot {
+  width: 5px; height: 5px;
+  border-radius: 50%;
+  background: var(--violet);
+  animation: pulse 2s infinite;
+}
+@keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.3} }
+
+h1 {
+  font-family: var(--fh);
+  font-size: clamp(28px, 4vw, 44px);
+  font-weight: 800;
+  line-height: 1.15;
+  letter-spacing: -0.5px;
+  margin-bottom: 10px;
+  color: #fff;
+}
+h1 span {
+  background: linear-gradient(135deg, var(--violet), var(--pink));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.subtitle {
+  color: var(--text-muted);
+  font-size: 15px;
+  font-weight: 300;
+  line-height: 1.6;
+  margin-bottom: 40px;
+}
+
+.spinner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--text-muted);
+  font-size: 14px;
+  padding: 40px 0;
+}
+.spin {
+  width: 18px; height: 18px;
+  border: 2px solid rgba(139,92,246,0.15);
+  border-top-color: var(--violet);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 60px 0;
+  color: var(--text-muted);
+  font-size: 15px;
+}
+.empty-icon { font-size: 40px; }
+
+.list { display: flex; flex-direction: column; gap: 10px; }
+
+.item {
+  background: var(--card);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: 14px;
+  padding: 16px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  transition: border-color 0.2s, background 0.2s;
+}
+.item:hover { background: #1A2238; border-color: rgba(255,255,255,0.14); }
+
+.item-left { display: flex; align-items: center; gap: 14px; min-width: 0; }
+
+.item-ico {
+  width: 38px; height: 38px;
+  border-radius: 10px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 17px;
+  flex-shrink: 0;
+}
+.item-ico--li { background: rgba(0,229,255,0.1); }
+.item-ico--cv { background: rgba(139,92,246,0.12); }
+
+.item-meta { min-width: 0; }
+.item-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #D8E0F0;
+  margin-bottom: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.item-date { font-size: 11px; color: #6B7590; }
+
+.item-right { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+
+.item-badge {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 10px;
+  border-radius: 20px;
+  background: rgba(74,222,128,0.1);
+  color: #4ADE80;
+  border: 1px solid rgba(74,222,128,0.2);
+  white-space: nowrap;
+}
+
+.dl-btn {
+  background: rgba(139,92,246,0.1);
+  border: 1px solid rgba(139,92,246,0.3);
+  border-radius: 8px;
+  color: var(--violet);
+  font-family: var(--fb);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 5px 13px;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+}
+.dl-btn:hover { background: rgba(139,92,246,0.2); }
+
+@media (max-width: 620px) {
+  .container { padding: 36px 18px; }
+  .item { flex-direction: column; align-items: flex-start; }
+  .item-right { width: 100%; justify-content: flex-end; }
+}
+</style>

--- a/frontend/src/views/HistoryView.vue
+++ b/frontend/src/views/HistoryView.vue
@@ -15,7 +15,7 @@
     </div>
 
     <div v-else class="list">
-      <div v-for="item in items" :key="item.id" class="item">
+      <div v-for="item in items" :key="item.id" class="item" @click="open(item)">
         <div class="item-left">
           <div class="item-ico" :class="item.agent === 'linkedin' ? 'item-ico--li' : 'item-ico--cv'">
             {{ item.agent === 'linkedin' ? '💼' : '📄' }}
@@ -27,24 +27,59 @@
                 : `CV adapté — ${item.input_data.job_offer?.slice(0, 50)}…` }}
             </div>
             <div class="item-date">{{ formatDate(item.created_at) }}</div>
+            <div class="item-preview">{{ item.preview }}</div>
           </div>
         </div>
         <div class="item-right">
           <span class="item-badge">Généré</span>
-          <button class="dl-btn" @click="download(item)">Télécharger</button>
+          <button class="dl-btn" @click.stop="download(item)">Télécharger</button>
         </div>
       </div>
     </div>
   </div>
+
+  <!-- Modal -->
+  <Teleport to="body">
+    <div v-if="selected" class="modal-backdrop" @click.self="close">
+      <div class="modal">
+        <div class="modal-header">
+          <div class="modal-title-wrap">
+            <span class="modal-ico" :class="selected.agent === 'linkedin' ? 'modal-ico--li' : 'modal-ico--cv'">
+              {{ selected.agent === 'linkedin' ? '💼' : '📄' }}
+            </span>
+            <span class="modal-title">
+              {{ selected.agent === 'linkedin'
+                ? `Post LinkedIn — ton ${selected.input_data.tone}`
+                : 'CV adapté' }}
+            </span>
+          </div>
+          <div class="modal-actions">
+            <button class="copy-btn" @click="copy(selected.output)">{{ copied ? 'Copié ✓' : 'Copier' }}</button>
+            <button class="dl-btn" @click="download(selected)">Télécharger</button>
+            <button class="close-btn" @click="close">✕</button>
+          </div>
+        </div>
+        <div class="modal-body">
+          <div v-if="selected.agent === 'cv' && selected.input_data.job_offer" class="modal-offer">
+            <div class="modal-offer-label">Offre d'emploi</div>
+            <div class="modal-offer-text">{{ selected.input_data.job_offer }}</div>
+          </div>
+          <div v-html="renderMd(selected.output)"></div>
+        </div>
+      </div>
+    </div>
+  </Teleport>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import { marked } from 'marked'
 import { getHistory } from '../services/api'
 
 const items = ref([])
 const loading = ref(true)
+const selected = ref(null)
+const copied = ref(false)
 
 onMounted(async () => {
   try {
@@ -52,13 +87,32 @@ onMounted(async () => {
   } finally {
     loading.value = false
   }
+  window.addEventListener('keydown', onKey)
 })
+onUnmounted(() => window.removeEventListener('keydown', onKey))
+
+function onKey(e) {
+  if (e.key === 'Escape') close()
+}
+
+function open(item) { selected.value = item }
+function close() { selected.value = null; copied.value = false }
 
 function formatDate(iso) {
   return new Date(iso).toLocaleDateString('fr-FR', {
     day: 'numeric', month: 'short', year: 'numeric',
     hour: '2-digit', minute: '2-digit',
   })
+}
+
+function renderMd(text) {
+  return text ? marked.parse(text) : ''
+}
+
+function copy(text) {
+  navigator.clipboard.writeText(text)
+  copied.value = true
+  setTimeout(() => { copied.value = false }, 2000)
 }
 
 function download(item) {
@@ -170,11 +224,12 @@ h1 span {
   align-items: center;
   justify-content: space-between;
   gap: 14px;
+  cursor: pointer;
   transition: border-color 0.2s, background 0.2s;
 }
-.item:hover { background: #1A2238; border-color: rgba(255,255,255,0.14); }
+.item:hover { background: #1A2238; border-color: rgba(139,92,246,0.3); }
 
-.item-left { display: flex; align-items: center; gap: 14px; min-width: 0; }
+.item-left { display: flex; align-items: flex-start; gap: 14px; min-width: 0; flex: 1; }
 
 .item-ico {
   width: 38px; height: 38px;
@@ -186,17 +241,26 @@ h1 span {
 .item-ico--li { background: rgba(0,229,255,0.1); }
 .item-ico--cv { background: rgba(139,92,246,0.12); }
 
-.item-meta { min-width: 0; }
+.item-meta { min-width: 0; flex: 1; }
 .item-title {
   font-size: 13px;
   font-weight: 600;
   color: #D8E0F0;
-  margin-bottom: 4px;
+  margin-bottom: 3px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.item-date { font-size: 11px; color: #6B7590; }
+.item-date { font-size: 11px; color: #6B7590; margin-bottom: 6px; }
+.item-preview {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
 
 .item-right { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
 
@@ -226,9 +290,152 @@ h1 span {
 }
 .dl-btn:hover { background: rgba(139,92,246,0.2); }
 
+/* Modal */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(4,6,12,0.85);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  animation: fadeIn 0.2s ease;
+}
+@keyframes fadeIn { from{opacity:0} to{opacity:1} }
+
+.modal {
+  background: var(--card);
+  border: 1px solid rgba(139,92,246,0.25);
+  border-radius: 20px;
+  width: 100%;
+  max-width: 740px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  animation: slideUp 0.25s ease;
+}
+@keyframes slideUp { from{transform:translateY(20px);opacity:0} to{transform:translateY(0);opacity:1} }
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid rgba(255,255,255,0.07);
+  background: rgba(139,92,246,0.06);
+  border-radius: 20px 20px 0 0;
+  gap: 12px;
+}
+.modal-title-wrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+.modal-ico {
+  width: 32px; height: 32px;
+  border-radius: 8px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 15px;
+  flex-shrink: 0;
+}
+.modal-ico--li { background: rgba(0,229,255,0.1); }
+.modal-ico--cv { background: rgba(139,92,246,0.12); }
+
+.modal-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.modal-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.copy-btn {
+  background: rgba(255,255,255,0.09);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: 8px;
+  color: #fff;
+  font-family: var(--fb);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 5px 13px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.copy-btn:hover { background: rgba(0,229,255,0.18); color: var(--cyan); border-color: rgba(0,229,255,0.4); }
+
+.close-btn {
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 8px;
+  color: var(--text-muted);
+  font-size: 14px;
+  padding: 5px 10px;
+  cursor: pointer;
+  transition: all 0.2s;
+  line-height: 1;
+}
+.close-btn:hover { background: rgba(248,113,113,0.15); color: #F87171; border-color: rgba(248,113,113,0.3); }
+
+.modal-body {
+  padding: 24px;
+  overflow-y: auto;
+  font-size: 14px;
+  line-height: 1.85;
+  color: var(--text-body);
+}
+.modal-body :deep(p) { margin-bottom: 0.75rem; }
+.modal-body :deep(strong) { color: var(--text); }
+.modal-body :deep(h1), .modal-body :deep(h2), .modal-body :deep(h3) {
+  font-family: var(--fh);
+  color: var(--text);
+  margin: 1.2rem 0 0.5rem;
+}
+.modal-offer {
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 10px;
+  padding: 14px 16px;
+  margin-bottom: 24px;
+}
+.modal-offer-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #6B7590;
+  margin-bottom: 8px;
+}
+.modal-offer-text {
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.6;
+  white-space: pre-wrap;
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+.modal-body :deep(ul), .modal-body :deep(ol) {
+  padding-left: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
 @media (max-width: 620px) {
   .container { padding: 36px 18px; }
   .item { flex-direction: column; align-items: flex-start; }
   .item-right { width: 100%; justify-content: flex-end; }
+  .modal { max-height: 90vh; }
+  .modal-header { flex-direction: column; align-items: flex-start; }
+  .modal-actions { width: 100%; justify-content: flex-end; }
 }
 </style>


### PR DESCRIPTION
  ## Summary                                                                     
                                                                                 
  - Backend : `GET /api/history/?session_id=<uuid>` — 20 dernières générations de
   la session                                                                    
  - Backend : `GenerationHistorySerializer` avec champ `preview`                 
  - Backend : sauvegarde complète de l'offre d'emploi (plus de troncature)       
  - Frontend : `HistoryView.vue` — liste avec aperçu, modal détail au clic       
  - Frontend : modal affiche l'offre d'emploi + output Markdown + boutons CV / LM
   séparés                                                                       
  - Frontend : lien Historique dans la nav, route `/history`                     
  - Chore : `.claude/settings.local.json` ajouté au `.gitignore` 