### PR TITLE
feat: implement CV analysis mode (M8)

### DIFF
--- a/backend/agents/serializers.py
+++ b/backend/agents/serializers.py
@@ -24,6 +24,7 @@ class CvRequestSerializer(serializers.Serializer):
     session_id = serializers.UUIDField()
     cv = serializers.FileField()
     cover_letter = serializers.FileField(required=False)
+    mode = serializers.ChoiceField(choices=["adapt", "analyze"], default="adapt")
 
     def validate_cv(self, value):
         if not value.name.endswith('.pdf'):

--- a/backend/agents/services/cv_agent.py
+++ b/backend/agents/services/cv_agent.py
@@ -58,3 +58,35 @@ CV actuel :
 {task}"""
 
     yield from stream(SYSTEM_PROMPT, user_message, cache_system=True)
+
+
+SYSTEM_PROMPT_ANALYZE = """Tu es un expert en recrutement avec 15 ans d'expérience.
+Tu analyses des CV par rapport à des offres d'emploi et fournis des retours actionnables.
+Tu écris uniquement en français.
+Tu retournes uniquement l'analyse structurée, sans commentaire introductif."""
+
+
+def analyze(job_offer: str, cv_text: str, cover_letter_text: str = ""):
+    lm_section = f"\n\nLettre de motivation :\n{cover_letter_text}" if cover_letter_text else ""
+
+    user_message = f"""Offre d'emploi :
+{job_offer}
+
+CV du candidat :
+{cv_text}{lm_section}
+
+Analyse ce CV par rapport à l'offre et structure ta réponse ainsi :
+
+## Points forts
+Liste les 4 à 6 points forts du candidat pour ce poste.
+
+## Points à améliorer
+Liste les 3 à 5 points faibles ou manquants par rapport aux exigences de l'offre.
+
+## Recommandations concrètes
+Donne 4 à 6 recommandations précises et actionnables pour améliorer le CV.
+
+## Score d'adéquation
+Donne un score sur 10 avec une justification en une phrase."""
+
+    yield from stream(SYSTEM_PROMPT_ANALYZE, user_message, cache_system=True)

--- a/backend/agents/views.py
+++ b/backend/agents/views.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from .models import Session, GenerationHistory
 from .serializers import LinkedInRequestSerializer, CvRequestSerializer, GenerationHistorySerializer
 from .services.linkedin_agent import generate as linkedin_agent_generate
-from .services.cv_agent import generate as cv_agent_generate, extract_text_from_pdf
+from .services.cv_agent import generate as cv_agent_generate, analyze as cv_agent_analyze, extract_text_from_pdf
 from .services.claude_client import ClaudeError
 
 
@@ -82,10 +82,13 @@ def cv_generate(request):
     except ClaudeError as e:
         return Response({'error': str(e)}, status=400)
 
+    mode = data.get('mode', 'adapt')
+    agent_fn = cv_agent_analyze if mode == 'analyze' else cv_agent_generate
+
     def event_stream():
         output_chunks = []
         try:
-            for chunk in cv_agent_generate(data['job_offer'], cv_text, cover_letter_text):
+            for chunk in agent_fn(data['job_offer'], cv_text, cover_letter_text):
                 output_chunks.append(chunk)
                 yield f"data: {json.dumps({'text': chunk})}\n\n"
 
@@ -93,7 +96,7 @@ def cv_generate(request):
             GenerationHistory.objects.create(
                 session=session,
                 agent="cv",
-                input_data={"job_offer": data['job_offer']},
+                input_data={"job_offer": data['job_offer'], "mode": mode},
                 output=full_output,
             )
             yield "data: [DONE]\n\n"

--- a/frontend/src/components/AnalysisCard.vue
+++ b/frontend/src/components/AnalysisCard.vue
@@ -1,0 +1,93 @@
+<template>
+  <div class="analysis-card">
+    <div v-if="streaming" class="streaming-indicator">
+      <span class="dot" /><span class="dot" /><span class="dot" />
+    </div>
+    <div class="analysis-content" v-html="renderedContent" />
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { marked } from 'marked'
+
+const props = defineProps({
+  content: { type: String, default: '' },
+  streaming: { type: Boolean, default: false },
+})
+
+const renderedContent = computed(() => marked.parse(props.content + (props.streaming ? '▍' : '')))
+</script>
+
+<style scoped>
+.analysis-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 2rem;
+  margin-top: 2rem;
+}
+
+.streaming-indicator {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 1rem;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--cyan);
+  animation: pulse 1.2s ease-in-out infinite;
+}
+.dot:nth-child(2) { animation-delay: 0.2s; }
+.dot:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.3; transform: scale(0.8); }
+  50% { opacity: 1; transform: scale(1); }
+}
+
+.analysis-content :deep(h2) {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--cyan);
+  margin: 1.5rem 0 0.75rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--border);
+}
+.analysis-content :deep(h2:first-child) { margin-top: 0; }
+
+.analysis-content :deep(ul) {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.5rem;
+}
+
+.analysis-content :deep(ul li) {
+  padding: 0.35rem 0 0.35rem 1.4rem;
+  position: relative;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.analysis-content :deep(ul li::before) {
+  content: '→';
+  position: absolute;
+  left: 0;
+  color: var(--violet);
+}
+
+.analysis-content :deep(p) {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0.5rem 0;
+}
+
+.analysis-content :deep(strong) {
+  color: var(--text);
+}
+</style>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -16,11 +16,12 @@ function getSessionId() {
   return id
 }
 
-export async function streamCv({ job_offer, cv, cover_letter, onChunk, onDone, onError }) {
+export async function streamCv({ job_offer, cv, cover_letter, mode = 'adapt', onChunk, onDone, onError }) {
   const formData = new FormData()
   formData.append('job_offer', job_offer)
   formData.append('session_id', getSessionId())
   formData.append('cv', cv)
+  formData.append('mode', mode)
   if (cover_letter) formData.append('cover_letter', cover_letter)
 
   const response = await fetch('/api/agents/cv/', {

--- a/frontend/src/views/CvView.vue
+++ b/frontend/src/views/CvView.vue
@@ -4,6 +4,15 @@
     <h1>Adapte ton CV &<br><span>ta lettre</span></h1>
     <p class="subtitle">Colle l'offre d'emploi, dépose tes documents — <strong>ton agent IA fait le reste.</strong></p>
 
+    <div class="mode-toggle">
+      <button :class="['mode-btn', { active: mode === 'adapt' }]" @click="mode = 'adapt'" :disabled="streaming">
+        Adapter
+      </button>
+      <button :class="['mode-btn', { active: mode === 'analyze' }]" @click="mode = 'analyze'" :disabled="streaming">
+        Analyser
+      </button>
+    </div>
+
     <form @submit.prevent="submit">
       <div class="field">
         <label>Offre d'emploi</label>
@@ -27,13 +36,15 @@
       </div>
 
       <button class="cta-btn" type="submit" :disabled="streaming || !canSubmit">
-        {{ streaming ? 'Adaptation en cours…' : 'Adapter mes documents →' }}
+        <template v-if="streaming">{{ mode === 'analyze' ? 'Analyse en cours…' : 'Adaptation en cours…' }}</template>
+        <template v-else>{{ mode === 'analyze' ? 'Analyser mes documents →' : 'Adapter mes documents →' }}</template>
       </button>
     </form>
 
     <p v-if="error" class="error-msg">{{ error }}</p>
 
-    <ResultCard :content="result" :streaming="streaming" />
+    <AnalysisCard v-if="mode === 'analyze'" :content="result" :streaming="streaming" />
+    <ResultCard v-else :content="result" :streaming="streaming" />
   </div>
 </template>
 
@@ -42,6 +53,7 @@ import { ref, computed } from 'vue'
 import { streamCv } from '../services/api'
 import FileUpload from '../components/FileUpload.vue'
 import ResultCard from '../components/ResultCard.vue'
+import AnalysisCard from '../components/AnalysisCard.vue'
 
 const jobOffer = ref('')
 const cvFile = ref(null)
@@ -49,6 +61,7 @@ const coverLetterFile = ref(null)
 const result = ref('')
 const streaming = ref(false)
 const error = ref('')
+const mode = ref('adapt')
 
 const canSubmit = computed(() => jobOffer.value.trim().length >= 20 && cvFile.value !== null)
 
@@ -62,6 +75,7 @@ async function submit() {
     job_offer: jobOffer.value,
     cv: cvFile.value,
     cover_letter: coverLetterFile.value,
+    mode: mode.value,
     onChunk: (text) => { result.value += text },
     onDone: () => { streaming.value = false },
     onError: (err) => {
@@ -124,9 +138,39 @@ h1 span {
   font-size: 15px;
   font-weight: 300;
   line-height: 1.6;
-  margin-bottom: 40px;
+  margin-bottom: 32px;
 }
 .subtitle strong { color: #C5CEDE; font-weight: 500; }
+
+.mode-toggle {
+  display: inline-flex;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 4px;
+  gap: 4px;
+  margin-bottom: 28px;
+}
+
+.mode-btn {
+  background: transparent;
+  border: none;
+  border-radius: 9px;
+  color: var(--text-muted);
+  font-family: var(--fb);
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 20px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.mode-btn:hover:not(:disabled):not(.active) { color: var(--text); }
+.mode-btn.active {
+  background: linear-gradient(135deg, rgba(0,200,224,0.2), rgba(124,58,237,0.2));
+  color: var(--cyan);
+  border: 1px solid rgba(0,200,224,0.3);
+}
+.mode-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .field { margin-bottom: 24px; }
 


### PR DESCRIPTION
## Summary

- Add Adapter/Analyser toggle on CV page — user picks between adaptation and analysis mode
- Backend routes `mode=analyze` to a dedicated Claude prompt returning structured feedback (strengths, improvements, recommendations, score /10)
- New `AnalysisCard.vue` component renders the streamed Markdown with cyan section headings and violet list markers
- `api.js` now forwards the `mode` param via `FormData`

## Test plan
- [ ] Upload a CV PDF + paste a job offer → Adapter mode → adapted CV streams correctly
- [ ] Switch to Analyser → streamed analysis shows the 4 sections (Points forts / À améliorer / Recommandations / Score)
- [ ] With cover letter uploaded → analysis includes LM section
- [ ] Toggle disabled while streaming

Closes #49
Closes #50
Closes #51
Closes #52
Closes #53
Closes #54
Closes #71
Closes #72
Closes #73
Closes #74
Closes #75
Closes #76

🤖 Generated with [Claude Code](https://claude.ai/claude-code)